### PR TITLE
Replace parse calls

### DIFF
--- a/src/main/java/jb/convert/ast/AssertConversion.java
+++ b/src/main/java/jb/convert/ast/AssertConversion.java
@@ -18,7 +18,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.github.javaparser.JavaParser.parseExpression;
+import static jb.convert.ast.tools.Expressions.fieldAccessExpressionFor;
 import static jb.convert.ast.tools.StaticImportBuilder.staticImportFrom;
 
 public class AssertConversion extends VoidVisitorAdapter<Object> implements Conversion {
@@ -60,7 +60,7 @@ public class AssertConversion extends VoidVisitorAdapter<Object> implements Conv
             if (scopeMatchesAssert(methodCall)) {
                 methodCall.getScope().ifPresent(scope -> {
                     scope.ifNameExpr(name -> name.setName("Assertions"));
-                    scope.ifFieldAccessExpr(fieldAccessExpr -> fieldAccessExpr.replace(parseExpression("org.junit.jupiter.api.Assertions")));
+                    scope.ifFieldAccessExpr(fieldAccessExpr -> fieldAccessExpr.replace(fieldAccessExpressionFor("org.junit.jupiter.api.Assertions")));
                 });
                 updated();
             }

--- a/src/main/java/jb/convert/ast/AssertThatConversion.java
+++ b/src/main/java/jb/convert/ast/AssertThatConversion.java
@@ -11,7 +11,6 @@ import com.github.javaparser.ast.visitor.Visitable;
 import jb.convert.ast.tools.Expressions;
 import jb.convert.ast.tools.ImportDeclarations;
 
-import static com.github.javaparser.JavaParser.parseImport;
 import static jb.convert.ast.tools.ImportDeclarations.addImportTo;
 
 public class AssertThatConversion extends ModifierVisitor<Void> implements Conversion {
@@ -43,7 +42,8 @@ public class AssertThatConversion extends ModifierVisitor<Void> implements Conve
                 scope.ifFieldAccessExpr(fieldAccessExpr -> fieldAccessExpr.replace(Expressions.fieldAccessExpressionFor("org.hamcrest.MatcherAssert")));
             });
             NodeList<ImportDeclaration> imports = ImportDeclarations.imports(methodCall);
-            if (imports.contains(parseImport("import static org.junit.Assert.*;"))) {
+            ImportDeclaration search = new ImportDeclaration("org.junit.Assert", true, true);
+            if (imports.contains(search)) {
                 updated();
                 addImportTo(methodCall, assertThatFromMatcherAssert());
             }
@@ -61,7 +61,7 @@ public class AssertThatConversion extends ModifierVisitor<Void> implements Conve
     }
 
     private ImportDeclaration assertThatFromMatcherAssert() {
-        return parseImport("import static org.hamcrest.MatcherAssert.assertThat;");
+        return new ImportDeclaration("org.hamcrest.MatcherAssert.assertThat", true, false);
     }
 
     @Override

--- a/src/main/java/jb/convert/ast/AssertThatConversion.java
+++ b/src/main/java/jb/convert/ast/AssertThatConversion.java
@@ -10,12 +10,15 @@ import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
 import jb.convert.ast.tools.Expressions;
 import jb.convert.ast.tools.ImportDeclarations;
+import jb.convert.ast.tools.StaticImportBuilder;
 
 import static jb.convert.ast.tools.ImportDeclarations.addImportTo;
+import static jb.convert.ast.tools.ImportDeclarations.importDeclarationFor;
+import static jb.convert.ast.tools.StaticImportBuilder.staticImportFrom;
 
 public class AssertThatConversion extends ModifierVisitor<Void> implements Conversion {
 
-    private static final ImportDeclaration junitAssertThat = JavaParser.parseImport("import static org.junit.Assert.assertThat;");
+    private static final ImportDeclaration junitAssertThat = importDeclarationFor(staticImportFrom(org.junit.Assert.class).method("assertThat"));
     private boolean updated = false;
 
 

--- a/src/main/java/jb/convert/ast/AssertThatConversion.java
+++ b/src/main/java/jb/convert/ast/AssertThatConversion.java
@@ -8,6 +8,7 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
+import jb.convert.ast.tools.Expressions;
 import jb.convert.ast.tools.ImportDeclarations;
 
 import static com.github.javaparser.JavaParser.parseImport;
@@ -39,7 +40,7 @@ public class AssertThatConversion extends ModifierVisitor<Void> implements Conve
         Visitable visit = super.visit(methodCall, arg);
         if ("assertThat".equals(methodCall.getNameAsString()) && hasTwoOrThreeArguments(methodCall)) {
             methodCall.getScope().ifPresent(scope -> {
-                scope.ifFieldAccessExpr(fieldAccessExpr -> fieldAccessExpr.replace(JavaParser.parseExpression("org.hamcrest.MatcherAssert")));
+                scope.ifFieldAccessExpr(fieldAccessExpr -> fieldAccessExpr.replace(Expressions.fieldAccessExpressionFor("org.hamcrest.MatcherAssert")));
             });
             NodeList<ImportDeclaration> imports = ImportDeclarations.imports(methodCall);
             if (imports.contains(parseImport("import static org.junit.Assert.*;"))) {

--- a/src/main/java/jb/convert/ast/CategoryConversion.java
+++ b/src/main/java/jb/convert/ast/CategoryConversion.java
@@ -22,7 +22,7 @@ import java.util.List;
 import static java.util.stream.Collectors.toList;
 
 public class CategoryConversion extends ModifierVisitor<Void> implements Conversion {
-    private static final ImportDeclaration categoryImport = JavaParser.parseImport("import org.junit.experimental.categories.Category;");
+    private static final ImportDeclaration categoryImport = new ImportDeclaration("org.junit.experimental.categories.Category", false, false);
     private final ProjectRecorder projectRecorder;
     private boolean updated = false;
 
@@ -63,7 +63,7 @@ public class CategoryConversion extends ModifierVisitor<Void> implements Convers
         List<ImportDeclaration> collect = imports.stream()
                 .filter(it -> it.getName().getIdentifier().equals(simpleName.getIdentifier()))
                 .collect(toList());
-        if (collect.isEmpty() || collect.size() > 1) {
+        if (collect.size() != 1) {
             throw new IllegalStateException("unable to resolve category class to single import, instead found " + collect.size());
         }
         Name category = collect.get(0).getName();

--- a/src/main/java/jb/convert/ast/GeneralConversion.java
+++ b/src/main/java/jb/convert/ast/GeneralConversion.java
@@ -9,7 +9,7 @@ import com.github.javaparser.ast.visitor.ModifierVisitor;
 import static jb.convert.ast.tools.Names.createNameFor;
 
 public class GeneralConversion extends ModifierVisitor<Void> implements Conversion {
-    private final ImportDeclaration junitStar = JavaParser.parseImport("import org.junit.*;");
+    private final ImportDeclaration junitStar = new ImportDeclaration("org.junit", false, true);
     private boolean updated;
 
     @Override

--- a/src/main/java/jb/convert/ast/GeneralConversion.java
+++ b/src/main/java/jb/convert/ast/GeneralConversion.java
@@ -5,6 +5,10 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
+import jb.convert.ast.tools.ImportDeclarations;
+import jb.convert.ast.tools.Names;
+
+import static jb.convert.ast.tools.Names.createNameFor;
 
 public class GeneralConversion extends ModifierVisitor<Void> implements Conversion {
     private final ImportDeclaration junitStar = JavaParser.parseImport("import org.junit.*;");
@@ -20,7 +24,7 @@ public class GeneralConversion extends ModifierVisitor<Void> implements Conversi
     public Node visit(ImportDeclaration importDeclaration, Void arg) {
         if (importDeclaration.equals(junitStar)) {
             updated();
-            return JavaParser.parseImport("import org.junit.jupiter.api.*;");
+            return new ImportDeclaration(createNameFor("org.junit.jupiter.api"), false, true);
         }
         return importDeclaration;
     }

--- a/src/main/java/jb/convert/ast/GeneralConversion.java
+++ b/src/main/java/jb/convert/ast/GeneralConversion.java
@@ -5,8 +5,6 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
-import jb.convert.ast.tools.ImportDeclarations;
-import jb.convert.ast.tools.Names;
 
 import static jb.convert.ast.tools.Names.createNameFor;
 

--- a/src/main/java/jb/convert/ast/TestAnnotationConversion.java
+++ b/src/main/java/jb/convert/ast/TestAnnotationConversion.java
@@ -19,11 +19,15 @@ import com.github.javaparser.ast.visitor.ModifierVisitor;
 import com.github.javaparser.ast.visitor.Visitable;
 import jb.configuration.JunitConversionLogicConfiguration;
 import jb.convert.ast.tools.ImportDeclarations;
+import jb.convert.ast.tools.StaticImportBuilder;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 
 import java.time.Duration;
 import java.util.Optional;
+
+import static jb.convert.ast.tools.ImportDeclarations.addStaticImportTo;
+import static jb.convert.ast.tools.StaticImportBuilder.staticImportFrom;
 
 public class TestAnnotationConversion extends ModifierVisitor<Void> implements Conversion {
     private final String assertTimeoutReplacementMethodName = "assertTimeoutPreemptively";
@@ -72,11 +76,10 @@ public class TestAnnotationConversion extends ModifierVisitor<Void> implements C
                 return;
             }
 
-            String importable = Assertions.class.getCanonicalName() + "." + assertTimeoutReplacementMethodName;
-
+            StaticImportBuilder importable = staticImportFrom(Assertions.class).method(assertTimeoutReplacementMethodName);
 
             ImportDeclarations.addImportTo(methodDeclaration, Duration.class);
-            ImportDeclarations.addStaticImportTo(methodDeclaration, importable);
+            addStaticImportTo(methodDeclaration, importable);
 
             Statement statement = JavaParser.parseStatement(assertTimeoutReplacementMethodName + "(Duration.ofMillis(" + timeoutInMillis + "L) ,()->" +
                     "" + configuration.javaParser().print(body) +
@@ -93,7 +96,7 @@ public class TestAnnotationConversion extends ModifierVisitor<Void> implements C
             if (body.getStatements().isEmpty()) {
                 return;
             }
-            ImportDeclarations.addStaticImportTo(methodDeclaration, Assertions.class.getCanonicalName() + ".assertThrows");
+            addStaticImportTo(methodDeclaration, staticImportFrom(Assertions.class).method("assertThrows"));
             Statement statement = JavaParser.parseStatement("assertThrows(" + exceptionClassAsString + ",()->" +
                     "" + configuration.javaParser().print(body) +
                     ");\n");

--- a/src/main/java/jb/convert/ast/tools/Annotations.java
+++ b/src/main/java/jb/convert/ast/tools/Annotations.java
@@ -1,7 +1,7 @@
 package jb.convert.ast.tools;
 
-import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 
 import java.lang.annotation.Annotation;
@@ -11,7 +11,8 @@ public class Annotations {
     public static void replace(NodeWithAnnotations<?> n, Class<? extends Annotation> junit4, Class<? extends Annotation> junit5, Callback callback) {
         Optional<AnnotationExpr> annotationByClass = n.getAnnotationByClass(junit4);
         annotationByClass.ifPresent(it -> {
-            it.replace(JavaParser.parseAnnotation("@" + junit5.getSimpleName()));
+            AnnotationExpr node = new MarkerAnnotationExpr(junit5.getSimpleName());
+            it.replace(node);
             callback.call();
         });
     }

--- a/src/main/java/jb/convert/ast/tools/Expressions.java
+++ b/src/main/java/jb/convert/ast/tools/Expressions.java
@@ -1,0 +1,21 @@
+package jb.convert.ast.tools;
+
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+
+public class Expressions {
+
+    public static Expression fieldAccessExpressionFor(String input) {
+        String[] parts = input.split("\\.");
+        Expression current = null;
+        for (String part : parts) {
+            if (current == null) {
+                current = new NameExpr(part);
+                continue;
+            }
+            current = new FieldAccessExpr(current, part);
+        }
+        return current;
+    }
+}

--- a/src/main/java/jb/convert/ast/tools/ImportDeclarations.java
+++ b/src/main/java/jb/convert/ast/tools/ImportDeclarations.java
@@ -51,6 +51,10 @@ public class ImportDeclarations {
 
     public static ImportDeclaration importDeclarationFor(StaticImportBuilder bluePrint) {
         StaticImport build = bluePrint.build();
-        return parseImport("import static " + build.className + "." + build.method + ";");
+        // in case it is a star import this information is passed in a flag and not in the name
+        String method = build.isStarImport() ? "" : "." + build.method;
+        Name name = Names.createNameFor(build.className.string + method);
+        return new ImportDeclaration(name, true, build.isStarImport());
     }
+
 }

--- a/src/main/java/jb/convert/ast/tools/ImportDeclarations.java
+++ b/src/main/java/jb/convert/ast/tools/ImportDeclarations.java
@@ -4,6 +4,7 @@ import com.github.javaparser.HasParentNode;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.Name;
 
 import static com.github.javaparser.JavaParser.parseImport;
 
@@ -44,7 +45,8 @@ public class ImportDeclarations {
     }
 
     public static ImportDeclaration importDeclarationFor(Class<?> replacementInJunit5) {
-        return parseImport("import " + replacementInJunit5.getCanonicalName() + ";");
+        Name name = Names.createNameFor(replacementInJunit5);
+        return new ImportDeclaration(name, false, false);
     }
 
     public static ImportDeclaration importDeclarationFor(StaticImportBuilder bluePrint) {

--- a/src/main/java/jb/convert/ast/tools/ImportDeclarations.java
+++ b/src/main/java/jb/convert/ast/tools/ImportDeclarations.java
@@ -6,8 +6,6 @@ import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.Name;
 
-import static com.github.javaparser.JavaParser.parseImport;
-
 public class ImportDeclarations {
 
     public static NodeList<ImportDeclaration> imports(HasParentNode<?> n) {
@@ -33,9 +31,8 @@ public class ImportDeclarations {
         addImportTo(node, importDeclarationFor(clazz));
     }
 
-    public static void addStaticImportTo(HasParentNode<?> target, String importable) {
-        ImportDeclaration staticImport = parseImport("import static " + importable + ";");
-        addImportTo(target, staticImport);
+    public static void addStaticImportTo(HasParentNode<?> target, StaticImportBuilder toAdd) {
+        addImportTo(target, importDeclarationFor(toAdd));
     }
 
     public static void addImportTo(HasParentNode<?> n, ImportDeclaration importDeclaration) {

--- a/src/main/java/jb/convert/ast/tools/Names.java
+++ b/src/main/java/jb/convert/ast/tools/Names.java
@@ -1,0 +1,22 @@
+package jb.convert.ast.tools;
+
+import com.github.javaparser.ast.expr.Name;
+
+public class Names {
+    public static Name createNameFor(Class<?> theClass) {
+        return createNameFor(theClass.getCanonicalName());
+    }
+
+    public static Name createNameFor(String canonicalName) {
+        String[] parts = canonicalName.split("\\.");
+        Name current = null;
+        for (String part : parts) {
+            if (current == null) {
+                current = new Name(part);
+                continue;
+            }
+            current = new Name(current, part);
+        }
+        return current;
+    }
+}

--- a/src/main/java/jb/convert/ast/tools/StaticImport.java
+++ b/src/main/java/jb/convert/ast/tools/StaticImport.java
@@ -2,11 +2,16 @@ package jb.convert.ast.tools;
 
 public class StaticImport {
 
+    public static final String SymbolForStarImport = "*";
     public final ClassName className;
     public final String method;
 
     public StaticImport(ClassName className, String method) {
         this.className = className;
         this.method = method;
+    }
+
+    public boolean isStarImport() {
+        return SymbolForStarImport.equals(this.method);
     }
 }

--- a/src/main/java/jb/convert/ast/tools/StaticImportBuilder.java
+++ b/src/main/java/jb/convert/ast/tools/StaticImportBuilder.java
@@ -19,7 +19,7 @@ public class StaticImportBuilder {
     }
 
     public StaticImportBuilder star() {
-        return method("*");
+        return method(StaticImport.SymbolForStarImport);
     }
 
     public StaticImportBuilder method(String method) {

--- a/src/test/java/jb/convert/ast/ImportDeclarationsTest.java
+++ b/src/test/java/jb/convert/ast/ImportDeclarationsTest.java
@@ -3,14 +3,13 @@ package jb.convert.ast;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
-import jb.convert.ast.tools.ImportDeclarations;
-import jb.convert.ast.tools.StaticImportBuilder;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static jb.convert.ast.tools.ImportDeclarations.addStaticImportTo;
 import static jb.convert.ast.tools.ImportDeclarations.importDeclarationFor;
+import static jb.convert.ast.tools.StaticImportBuilder.staticImportFrom;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.startsWith;
 
@@ -20,22 +19,22 @@ class ImportDeclarationsTest {
     void doNotAddDuplicateImports() {
         CompilationUnit cu = new CompilationUnit("org");
         ClassOrInterfaceDeclaration type = cu.addClass("Type");
-        ImportDeclarations.addStaticImportTo(type, "org.example.method");
-        ImportDeclarations.addStaticImportTo(type, "org.example.method");
+        addStaticImportTo(type, staticImportFrom(String.class).method("method"));
+        addStaticImportTo(type, staticImportFrom(String.class).method("method"));
 
         assertThat(cu.getImports(), hasSize(1));
     }
 
     @Test
     void deriveProperImportDeclarationForStaticStarImport() {
-        ImportDeclaration importDeclaration = importDeclarationFor(StaticImportBuilder.staticImportFrom(Tag.class).star());
+        ImportDeclaration importDeclaration = importDeclarationFor(staticImportFrom(Tag.class).star());
 
         assertThat(importDeclaration.toString(), startsWith("import static org.junit.jupiter.api.Tag.*;"));
     }
 
     @Test
     void deriveProperImportDeclarationForStaticMethodImport() {
-        ImportDeclaration importDeclaration = importDeclarationFor(StaticImportBuilder.staticImportFrom(Tag.class).method("banana"));
+        ImportDeclaration importDeclaration = importDeclarationFor(staticImportFrom(Tag.class).method("banana"));
 
         assertThat(importDeclaration.toString(), startsWith("import static org.junit.jupiter.api.Tag.banana;"));
     }

--- a/src/test/java/jb/convert/ast/ImportDeclarationsTest.java
+++ b/src/test/java/jb/convert/ast/ImportDeclarationsTest.java
@@ -1,12 +1,18 @@
 package jb.convert.ast;
 
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import jb.convert.ast.tools.ImportDeclarations;
+import jb.convert.ast.tools.StaticImportBuilder;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static jb.convert.ast.tools.ImportDeclarations.importDeclarationFor;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.startsWith;
 
 class ImportDeclarationsTest {
 
@@ -18,5 +24,19 @@ class ImportDeclarationsTest {
         ImportDeclarations.addStaticImportTo(type, "org.example.method");
 
         assertThat(cu.getImports(), hasSize(1));
+    }
+
+    @Test
+    void deriveProperImportDeclarationForStaticStarImport() {
+        ImportDeclaration importDeclaration = importDeclarationFor(StaticImportBuilder.staticImportFrom(Tag.class).star());
+
+        assertThat(importDeclaration.toString(), startsWith("import static org.junit.jupiter.api.Tag.*;"));
+    }
+
+    @Test
+    void deriveProperImportDeclarationForStaticMethodImport() {
+        ImportDeclaration importDeclaration = importDeclarationFor(StaticImportBuilder.staticImportFrom(Tag.class).method("banana"));
+
+        assertThat(importDeclaration.toString(), startsWith("import static org.junit.jupiter.api.Tag.banana;"));
     }
 }

--- a/src/test/java/jb/convert/ast/tools/ExpressionsTest.java
+++ b/src/test/java/jb/convert/ast/tools/ExpressionsTest.java
@@ -1,0 +1,21 @@
+package jb.convert.ast.tools;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.expr.Expression;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class ExpressionsTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"org.hamcrest.MatcherAssert", "org.junit.jupiter.api.Assertions"})
+    void ensureTheGeneratedExpressionsAreAtLeastEqual(String input) {
+        Expression replacement = Expressions.fieldAccessExpressionFor(input);
+        Expression parsedByJavaParser = JavaParser.parseExpression(input);
+
+        assertThat(replacement, equalTo(parsedByJavaParser));
+    }
+}

--- a/src/test/java/jb/convert/ast/tools/NamesTest.java
+++ b/src/test/java/jb/convert/ast/tools/NamesTest.java
@@ -1,0 +1,17 @@
+package jb.convert.ast.tools;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static jb.convert.ast.tools.Names.createNameFor;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class NamesTest {
+
+    @Test
+    void constructANameFromAClass() {
+        assertThat(createNameFor(Tag.class).asString(), equalTo(Tag.class.getCanonicalName()) );
+    }
+
+}


### PR DESCRIPTION
The parse calls create a `JavaParser` instance that uses a shared configuration  object.
While trying to fix the windows build this turned out to be problematic with the `preserver formatting` feature.
This PR replaces most of the `JavaParser.parse*` calls used to create AST nodes with manual creation.
Not all of them have been replaced yet, but with those changes the next steps should be easier.