### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v2.3.0
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: Cache Gradle
         uses: actions/cache@v2.1.6
         with:


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK.

Signed-off-by: Carl Dea <carldea@gmail.com>